### PR TITLE
Add implementation docs for EOT migration

### DIFF
--- a/Implement.md
+++ b/Implement.md
@@ -1,0 +1,10 @@
+# Edge of Time Implementation Notes
+
+This repository was designed for Sonic Unleashed. Porting it for **Edge of Time (EOT)** requires changes across multiple modules.
+
+General tasks:
+
+- Point the build system to `rebluelib/config/EOTConfig.toml` and update presets.
+- Remove Unleashed specific sources from CMake until EOT pieces compile.
+- Integrate shader extraction and recompilation steps in the build.
+- Review kernel offsets, memory mapping and boundary issues.

--- a/reblue/Implement.md
+++ b/reblue/Implement.md
@@ -1,0 +1,9 @@
+# Edge of Time Port
+
+The `reblue` directory contains the main runtime. Key work needed for EOT:
+
+- Update hard coded paths in `main.cpp` to point to your EOT game data.
+- Change `user/paths.h` and registry strings to use an EOT specific name.
+- Remove Sonic‐specific code and assets from the build list.
+- Locate kernel call offsets and implement missing functions in `kernel/`.
+- Ensure memory mapping of the base XEX matches the guest code so debug symbols line up.

--- a/reblue/apu/Implement.md
+++ b/reblue/apu/Implement.md
@@ -1,0 +1,7 @@
+# Audio System
+
+Edge of Time may use different sound formats and buffering logic.
+
+- Confirm the SDL2 driver in `driver/` can play EOT's audio files.
+- Fix any buffer boundary issues found during playback tests.
+- Implement additional XAudio/AL emulation if kernel calls require it.

--- a/reblue/apu/driver/Implement.md
+++ b/reblue/apu/driver/Implement.md
@@ -1,0 +1,3 @@
+# APU Driver
+
+`sdl2_driver.cpp` handles audio output. Check for missing callbacks or unsupported sample rates when running EOT. Add new driver logic as necessary.

--- a/reblue/cpu/Implement.md
+++ b/reblue/cpu/Implement.md
@@ -1,0 +1,6 @@
+# CPU Emulation
+
+EOT requires accurate mapping of the base XEX.
+
+- Verify guest thread creation and stack sizes in `guest_thread.*`.
+- Ensure memory regions match EOT's expectations so host/guest addresses translate correctly.

--- a/reblue/gpu/Implement.md
+++ b/reblue/gpu/Implement.md
@@ -1,0 +1,7 @@
+# GPU Backend
+
+Edge of Time's shaders and render states differ from Unleashed.
+
+- Strip Sonic-specific hacks in `video.cpp`.
+- Implement shader extraction tooling and caching under `shader/`.
+- Reverse engineer where EOT stores shaders and integrate with the build pipeline.

--- a/reblue/gpu/cache/Implement.md
+++ b/reblue/gpu/cache/Implement.md
@@ -1,0 +1,3 @@
+# Pipeline Caches
+
+Verify that pipeline and vertex declaration caches work with EOT's render states. Adjust hashing if the shader layout changes.

--- a/reblue/gpu/imgui/Implement.md
+++ b/reblue/gpu/imgui/Implement.md
@@ -1,0 +1,3 @@
+# ImGui Layer
+
+Check if additional UI debugging views are needed for EOT rendering issues. Update initialization if backend APIs change.

--- a/reblue/gpu/rhi/Implement.md
+++ b/reblue/gpu/rhi/Implement.md
@@ -1,0 +1,3 @@
+# Rendering Hardware Interface
+
+Ensure the Vulkan/D3D12 backends implement features required by EOT's shaders. Pay attention to memory barriers and texture formats.

--- a/reblue/gpu/shader/Implement.md
+++ b/reblue/gpu/shader/Implement.md
@@ -1,0 +1,3 @@
+# Shader Utilities
+
+Add tooling here to compile and cache Edge of Time shaders after extraction. This ties into the build steps described in the root notes.

--- a/reblue/hid/Implement.md
+++ b/reblue/hid/Implement.md
@@ -1,0 +1,3 @@
+# Input System
+
+Test controller mappings against EOT. Adjust the SDL driver if button layouts differ. Implement any missing HID commands.

--- a/reblue/hid/driver/Implement.md
+++ b/reblue/hid/driver/Implement.md
@@ -1,0 +1,3 @@
+# HID Driver
+
+`sdl_hid.cpp` is responsible for device enumeration. Extend it to recognise any extra devices used by Edge of Time.

--- a/reblue/kernel/Implement.md
+++ b/reblue/kernel/Implement.md
@@ -1,0 +1,5 @@
+# Kernel Emulation
+
+- Implement missing Xbox kernel calls needed by EOT.
+- Add objects under `obj/` as you encounter new handles or events.
+- Verify networking and file system behavior with the game's expectations.

--- a/reblue/kernel/io/Implement.md
+++ b/reblue/kernel/io/Implement.md
@@ -1,0 +1,3 @@
+# Kernel I/O
+
+Check the virtual file system layer for path differences. EOT might load assets from different mount points.

--- a/reblue/kernel/obj/Implement.md
+++ b/reblue/kernel/obj/Implement.md
@@ -1,0 +1,4 @@
+# Kernel Objects
+
+Edge of Time may rely on events, semaphores or mutants not yet implemented.
+Create the required classes here and ensure handles mirror Xbox behavior.

--- a/reblue/locale/Implement.md
+++ b/reblue/locale/Implement.md
@@ -1,0 +1,3 @@
+# Localisation
+
+Replace all Unleashed references with Edge of Time branding. Verify translated strings still fit UI constraints.

--- a/reblue/os/Implement.md
+++ b/reblue/os/Implement.md
@@ -1,0 +1,3 @@
+# OS Layer
+
+Ensure file paths and user directories match the EOT install. Update process spawning and registry helpers if needed.

--- a/reblue/os/linux/Implement.md
+++ b/reblue/os/linux/Implement.md
@@ -1,0 +1,4 @@
+# Linux Specific Notes
+
+- Verify SDL and Vulkan dependencies work on Linux.
+- Update any hard coded paths from the Windows version.

--- a/reblue/os/win32/Implement.md
+++ b/reblue/os/win32/Implement.md
@@ -1,0 +1,4 @@
+# Windows Specific Notes
+
+- Registry entries reference `UnleashedRecomp`. Update these to EOT.
+- Ensure timeBeginPeriod usage and other Win32 calls behave correctly on modern Windows.

--- a/reblue/res/Implement.md
+++ b/reblue/res/Implement.md
@@ -1,0 +1,3 @@
+# Build Resources
+
+Update the version templates and icon resources for Edge of Time branding. Windows resource script under `win32` will need new IDs.

--- a/reblue/res/win32/Implement.md
+++ b/reblue/res/win32/Implement.md
@@ -1,0 +1,3 @@
+# Windows Resources
+
+`res.rc.template` still contains Unleashed icons and strings. Replace them with Edge of Time assets.

--- a/reblue/ui/Implement.md
+++ b/reblue/ui/Implement.md
@@ -1,0 +1,3 @@
+# User Interface
+
+EOT may have different menu layouts. Review all UI classes here and strip or replace Unleashed specific code.

--- a/reblue/user/Implement.md
+++ b/reblue/user/Implement.md
@@ -1,0 +1,4 @@
+# User Data
+
+- Rename `USER_DIRECTORY` in `paths.h`.
+- Verify achievement and registry systems load Edge of Time data correctly.

--- a/rebluelib/Implement.md
+++ b/rebluelib/Implement.md
@@ -1,0 +1,7 @@
+# Recompiler Library
+
+`rebluelib` houses the PowerPC recompiler. Tasks for EOT include:
+
+- Fill in EOT specific addresses in `config/`.
+- Label every known function in Ghidra/IDA for easier debugging.
+- Add support for any missing instruction forms or kernel stubs.

--- a/rebluelib/config/Implement.md
+++ b/rebluelib/config/Implement.md
@@ -1,0 +1,3 @@
+# EOT Configuration
+
+`EOTConfig.toml` and `EOTJumpTable.toml` store function addresses and switch tables. Update these when you discover new offsets or when the game is patched.

--- a/resources/Implement.md
+++ b/resources/Implement.md
@@ -1,0 +1,3 @@
+# Game Resources
+
+Replace placeholder resources with assets extracted from Edge of Time. Fonts, images, music and sounds under this folder should match the target game.

--- a/resources/bc_diff/Implement.md
+++ b/resources/bc_diff/Implement.md
@@ -1,0 +1,3 @@
+# BC Diff Files
+
+This directory stores reference data used by `bc_diff` tool. Update with Edge of Time bytecode samples when available.

--- a/resources/font/Implement.md
+++ b/resources/font/Implement.md
@@ -1,0 +1,3 @@
+# Fonts
+
+If Edge of Time uses different fonts, regenerate the ImGui atlas and drop them here.

--- a/resources/images/Implement.md
+++ b/resources/images/Implement.md
@@ -1,0 +1,3 @@
+# Images
+
+Replace Unleashed branding with Edge of Time logos and menu art. The installer graphics under `installer/` should also be updated.

--- a/resources/music/Implement.md
+++ b/resources/music/Implement.md
@@ -1,0 +1,3 @@
+# Music
+
+Swap out any placeholder tracks with the correct Edge of Time audio.

--- a/resources/sounds/Implement.md
+++ b/resources/sounds/Implement.md
@@ -1,0 +1,3 @@
+# Sound Effects
+
+Ensure all sound effects match those extracted from Edge of Time.

--- a/scripts/Implement.md
+++ b/scripts/Implement.md
@@ -1,0 +1,3 @@
+# Scripts
+
+Add automation scripts here for extracting and preparing Edge of Time data. Existing QuickBMS scripts may require updates for new archive formats.

--- a/scripts/ida/Implement.md
+++ b/scripts/ida/Implement.md
@@ -1,0 +1,3 @@
+# IDA Helpers
+
+Use the scripts in this folder to label every possible function in the EOT binary. Accurate names aid debugging when the recompilation throws exceptions.

--- a/tools/Implement.md
+++ b/tools/Implement.md
@@ -1,0 +1,7 @@
+# Tools Overview
+
+The tools help build and analyze game data. Several need updates for Edge of Time:
+
+- Integrate shader extraction using quickbms.
+- Extend `bc_diff` and `fshasher` to recognise new formats.
+- Fill out `XenosRecomp` and `XenonRecomp` for the recompilation pipeline.

--- a/tools/bc_diff/Implement.md
+++ b/tools/bc_diff/Implement.md
@@ -1,0 +1,3 @@
+# Bytecode Diff Tool
+
+Update this utility to handle Edge of Time scripts and improve boundary checking.

--- a/tools/file_to_c/Implement.md
+++ b/tools/file_to_c/Implement.md
@@ -1,0 +1,3 @@
+# File to C Converter
+
+Use this to embed shader binaries or configuration defaults extracted from EOT.

--- a/tools/fshasher/Implement.md
+++ b/tools/fshasher/Implement.md
@@ -1,0 +1,3 @@
+# FSHasher Tool
+
+Extend hash logic if Edge of Time uses new file naming conventions or mount points.

--- a/tools/x_decompress/Implement.md
+++ b/tools/x_decompress/Implement.md
@@ -1,0 +1,3 @@
+# X Decompress Utility
+
+Ensure this tool can decompress Edge of Time pack files before shader extraction.


### PR DESCRIPTION
## Summary
- outline global steps for porting the codebase to Edge of Time
- add per-folder `Implement.md` files with TODO notes

## Testing
- `cmake -S . -B build` *(fails: VCPKG_ROOT is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685ca4cfda648325ac478bed728d9059