### PR TITLE
Switch to EOT defaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.20)
 
 if(NOT DEFINED ENV{VCPKG_ROOT})
-    message(FATAL_ERROR "VCPKG_ROOT is not defined!")
+    set(ENV{VCPKG_ROOT} "${CMAKE_SOURCE_DIR}/thirdparty/vcpkg")
 endif()
 
 include($ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake)
@@ -26,9 +26,9 @@ add_compile_options(
     -march=sandybridge
 )
 
-project("reblue-all")
+project("eot-all")
 
 add_subdirectory(${REBLUE_THIRDPARTY_ROOT})
 add_subdirectory(${REBLUE_TOOLS_ROOT})
-add_subdirectory("rebluelib")
-add_subdirectory("reblue")
+add_subdirectory("EOTLib")
+add_subdirectory("EOTMain")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -5,7 +5,7 @@
             "name": "windows-base",
             "hidden": true,
             "generator": "Ninja",
-            "binaryDir": "${sourceDir}/out/build/${presetName}",
+            "binaryDir": "${sourceDir}/out/build/eot-${presetName}",
             "installDir": "${sourceDir}/out/install/${presetName}",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "clang-cl.exe",
@@ -62,7 +62,7 @@
             "name": "linux-base",
             "hidden": true,
             "generator": "Ninja",
-            "binaryDir": "${sourceDir}/out/build/${presetName}",
+            "binaryDir": "${sourceDir}/out/build/eot-${presetName}",
             "installDir": "${sourceDir}/out/install/${presetName}",
             "cacheVariables": {
                 "CMAKE_TOOLCHAIN_FILE": {

--- a/EOTLib/CMakeLists.txt
+++ b/EOTLib/CMakeLists.txt
@@ -16,10 +16,10 @@ set(REBLUE_PPC_RECOMPILED_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/ppc/ppc_func_mapping.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/ppc/ppc_recomp_shared.h"
 )
-set(REBLUE_CONFIG_FILE="${CMAKE_CURRENT_SOURCE_DIR}/config/config.toml")
+set(REBLUE_CONFIG_FILE="${CMAKE_CURRENT_SOURCE_DIR}/config/EOTConfig.toml")
 
 target_compile_definitions(XenonRecomp PRIVATE 
-    XENON_RECOMP_CONFIG_FILE_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/config/config.toml\"
+    XENON_RECOMP_CONFIG_FILE_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/config/EOTConfig.toml\"
     XENON_RECOMP_HEADER_FILE_PATH=\"${REBLUE_TOOLS_ROOT}/XenonRecomp/XenonUtils/ppc_context.h\")
 
  foreach(i RANGE 0 74)
@@ -33,7 +33,7 @@ add_custom_command(
         $<TARGET_FILE:XenonRecomp>
     DEPENDS 
         "${CMAKE_CURRENT_SOURCE_DIR}/private/default.xex"
-        "${CMAKE_CURRENT_SOURCE_DIR}/config/config.toml"
+        "${CMAKE_CURRENT_SOURCE_DIR}/config/EOTConfig.toml"
 )
 
 

--- a/EOTMain/CMakeLists.txt
+++ b/EOTMain/CMakeLists.txt
@@ -2,6 +2,14 @@ project("reblue")
 
 if (WIN32)
     option(UNLEASHED_RECOMP_D3D12 "Add D3D12 support for rendering" ON)
+    if (UNLEASHED_RECOMP_D3D12)
+        find_library(D3D12_LIB d3d12 HINTS $ENV{WindowsSdkDir}/Lib
+            PATH_SUFFIXES "x64" "x86" "um/x64" "um/x86")
+        if (NOT D3D12_LIB)
+            message(WARNING "D3D12.lib not found - disabling UNLEASHED_RECOMP_D3D12")
+            set(UNLEASHED_RECOMP_D3D12 OFF)
+        endif()
+    endif()
 endif()
 
 add_compile_options(
@@ -114,30 +122,30 @@ set(REBLUE_UI_CXX_SOURCES
 #    "ui/tv_static.cpp"
 )
 
-set(REBLUE_INSTALL_CXX_SOURCES
-    "install/installer.cpp"
-    "install/iso_file_system.cpp"
-    "install/update_checker.cpp"
-    "install/xcontent_file_system.cpp"
-    "install/hashes/apotos_shamar.cpp"
-    "install/hashes/chunnan.cpp"
-    "install/hashes/empire_city_adabat.cpp"
-    "install/hashes/game.cpp"
-    "install/hashes/holoska.cpp"
-    "install/hashes/mazuri.cpp"
-    "install/hashes/spagonia.cpp"
-    "install/hashes/update.cpp"
-)
+#set(REBLUE_INSTALL_CXX_SOURCES
+#    "install/installer.cpp"
+#    "install/iso_file_system.cpp"
+#    "install/update_checker.cpp"
+#    "install/xcontent_file_system.cpp"
+#    "install/hashes/apotos_shamar.cpp"
+#    "install/hashes/chunnan.cpp"
+#    "install/hashes/empire_city_adabat.cpp"
+#    "install/hashes/game.cpp"
+#    "install/hashes/holoska.cpp"
+#    "install/hashes/mazuri.cpp"
+#    "install/hashes/spagonia.cpp"
+#    "install/hashes/update.cpp"
+#)
 
-set(REBLUE_USER_CXX_SOURCES
-    "user/achievement_data.cpp"
-    #"user/achievement_manager.cpp"
-    "user/config.cpp"
+#set(REBLUE_USER_CXX_SOURCES
+#    "user/achievement_data.cpp"
+#    #"user/achievement_manager.cpp"
+#    "user/config.cpp"
     "user/registry.cpp"
     "user/paths.cpp"
     "user/persistent_data.cpp"
-    "user/persistent_storage_manager.cpp"
-)
+#    "user/persistent_storage_manager.cpp"
+#)
 
 set(REBLUE_MOD_CXX_SOURCES
     "mod/mod_loader.cpp"

--- a/EOTMain/main.cpp
+++ b/EOTMain/main.cpp
@@ -138,7 +138,7 @@ int main(int argc, char *argv[])
     const char *sdlVideoDriver = nullptr;
 
     // bootleg paths
-    std::filesystem::path reblueBinPath = "P:\\x360\\reblue-game\\bin";
+    std::filesystem::path reblueBinPath = "../EOTLib/private";
 
     if (!useDefaultWorkingDirectory)
     {
@@ -171,7 +171,7 @@ int main(int argc, char *argv[])
 
     hid::Init();
 
-    std::filesystem::path modulePath = reblueBinPath.append("default.xex");
+    std::filesystem::path modulePath = reblueBinPath / "default.xex";
     bool isGameInstalled = true;// Installer::checkGameInstall(GAME_INSTALL_DIRECTORY, modulePath);
     bool runInstallerWizard = forceInstaller || forceDLCInstaller || !isGameInstalled;
     //if (runInstallerWizard)
@@ -204,8 +204,8 @@ int main(int argc, char *argv[])
     const auto gameContent = reblue::kernel::XamMakeContent(XCONTENTTYPE_RESERVED, "Game");
     const auto cacheContent = reblue::kernel::XamMakeContent(XCONTENTTYPE_RESERVED, "Cache");
 
-    reblue::kernel::XamRegisterContent(gameContent, "P:/x360/reblue-game/game");
-    reblue::kernel::XamRegisterContent(cacheContent, "P:/x360/reblue-game/cache");
+    reblue::kernel::XamRegisterContent(gameContent, "P:/x360/eot-game/game");
+    reblue::kernel::XamRegisterContent(cacheContent, "P:/x360/eot-game/cache");
 
     // Mount game
     reblue::kernel::XamContentCreateEx(0, "game", &gameContent, OPEN_EXISTING, nullptr, nullptr, 0, 0, nullptr);


### PR DESCRIPTION
## Summary
- update project to reference `EOTLib` and `EOTMain`
- point the recompiler to `config/EOTConfig.toml`
- pick up `default.xex` from `EOTLib/private`
- change sample runtime paths in `main.cpp`
- comment out some Sonic–specific source lists
- put builds under `out/build/eot-*`
- define default `VCPKG_ROOT` inside the root CMake file
- automatically disable the D3D12 feature when `D3D12.lib` can't be located

## Testing
- `cmake --preset=linux-debug` *(fails: Could not find vcpkg toolchain and Ninja)*

------
https://chatgpt.com/codex/tasks/task_e_685ccf77ded08325bf4176dc76f11317